### PR TITLE
Task/447178 epr payment frontend sonarqube cleanup

### DIFF
--- a/src/EPR.Payment.Portal.Common.UnitTests/RESTServices/HttpPaymentFacadeTests.cs
+++ b/src/EPR.Payment.Portal.Common.UnitTests/RESTServices/HttpPaymentFacadeTests.cs
@@ -53,9 +53,8 @@ namespace EPR.Payment.Portal.Common.UnitTests.RESTServices
         public async Task CompletePaymentAsync_Success_ReturnsPaymentDetailsDto(
             [Frozen] Mock<HttpMessageHandler> handlerMock,
             HttpPaymentFacade httpPaymentsFacade,
-            CancellationToken cancellationToken,
             Guid externalPaymentId,
-            CompletePaymentResponseDto completePaymentResponseDto)
+            CompletePaymentResponseDto completePaymentResponseDto, CancellationToken cancellationToken)
         {
             // Arrange
             handlerMock.Protected()
@@ -89,8 +88,7 @@ namespace EPR.Payment.Portal.Common.UnitTests.RESTServices
         public async Task CompletePaymentAsync_Failure_ThrowsException(
             [Frozen] Mock<HttpMessageHandler> handlerMock,
             HttpPaymentFacade httpPaymentsFacade,
-            CancellationToken cancellationToken,
-            Guid externalPaymentId)
+            Guid externalPaymentId, CancellationToken cancellationToken)
         {
             // Arrange
 
@@ -121,9 +119,8 @@ namespace EPR.Payment.Portal.Common.UnitTests.RESTServices
         public async Task InitiatePaymentAsync_Success_ReturnsPaymentDetailsDto(
             [Frozen] Mock<HttpMessageHandler> handlerMock,
             HttpPaymentFacade httpPaymentsFacade,
-            CancellationToken cancellationToken,
             PaymentRequestDto request,
-            string response)
+            string response, CancellationToken cancellationToken)
         {
             // Arrange
             handlerMock.Protected()
@@ -157,8 +154,7 @@ namespace EPR.Payment.Portal.Common.UnitTests.RESTServices
         public async Task InitiatePaymentAsync_Failure_ThrowsException(
             [Frozen] Mock<HttpMessageHandler> handlerMock,
             HttpPaymentFacade httpPaymentsFacade,
-            CancellationToken cancellationToken,
-            PaymentRequestDto request)
+            PaymentRequestDto request, CancellationToken cancellationToken)
         {
             // Arrange
 

--- a/src/EPR.Payment.Portal.Common/Profiles/PaymentProfile.cs
+++ b/src/EPR.Payment.Portal.Common/Profiles/PaymentProfile.cs
@@ -8,7 +8,7 @@ namespace EPR.Payment.Portal.Common.Profiles
     {
         public PaymentProfile()
         {
-            //todo:For now, amount is added as int and decimal in different projects. It will be deleted when decided.
+            //For now, amount is added as int and decimal in different projects. It will be deleted when decided.
             CreateMap<CompletePaymentResponseDto, CompletePaymentViewModel > ().ForMember(dest => dest.Amount, opt => opt.MapFrom(src => (src.Amount != null ? (int)src.Amount : 0))); 
         }
     }

--- a/src/EPR.Payment.Portal.Common/RESTServices/BaseHttpService.cs
+++ b/src/EPR.Payment.Portal.Common/RESTServices/BaseHttpService.cs
@@ -26,7 +26,7 @@ namespace EPR.Payment.Portal.Common.RESTServices
             // Initialize _baseUrl in the constructor
             _baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? throw new ArgumentNullException(nameof(baseUrl)) : baseUrl;
 
-           ArgumentNullException.ThrowIfNull(httpClientFactory, nameof(httpClientFactory));
+           ArgumentNullException.ThrowIfNull(httpClientFactory);
 
             if (string.IsNullOrWhiteSpace(endPointName))
                 throw new ArgumentNullException(nameof(endPointName));

--- a/src/EPR.Payment.Portal.Common/RESTServices/BaseHttpService.cs
+++ b/src/EPR.Payment.Portal.Common/RESTServices/BaseHttpService.cs
@@ -26,8 +26,7 @@ namespace EPR.Payment.Portal.Common.RESTServices
             // Initialize _baseUrl in the constructor
             _baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? throw new ArgumentNullException(nameof(baseUrl)) : baseUrl;
 
-            if (httpClientFactory == null)
-                throw new ArgumentNullException(nameof(httpClientFactory));
+           ArgumentNullException.ThrowIfNull(httpClientFactory, nameof(httpClientFactory));
 
             if (string.IsNullOrWhiteSpace(endPointName))
                 throw new ArgumentNullException(nameof(endPointName));
@@ -35,7 +34,7 @@ namespace EPR.Payment.Portal.Common.RESTServices
             _httpClient = httpClientFactory.CreateClient();
             _httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
 
-            if (_baseUrl.EndsWith("/"))
+            if (_baseUrl.EndsWith('/'))
                 _baseUrl = _baseUrl.TrimEnd('/');
 
             _baseUrl = $"{_baseUrl}/{endPointName}";

--- a/src/EPR.Payment.Portal.Common/Validators/ValidUrlAttribute.cs
+++ b/src/EPR.Payment.Portal.Common/Validators/ValidUrlAttribute.cs
@@ -14,8 +14,9 @@ namespace EPR.Payment.Portal.Common.Validators
 
             string url = value.ToString()!;
             string pattern = @"^(http|https)://([\w-]+(\.[\w-]+)+)([/#?]?.*)$";
+            var matchTimeout = TimeSpan.FromMilliseconds(100);
 
-            if (!Regex.IsMatch(url, pattern))
+            if (!Regex.IsMatch(url, pattern, RegexOptions.None, matchTimeout))
             {
                 return new ValidationResult("The URL is not valid.");
             }

--- a/src/EPR.Payment.Portal/Dockerfile
+++ b/src/EPR.Payment.Portal/Dockerfile
@@ -32,7 +32,7 @@ COPY EPR.Payment.Portal.Common/. ./EPR.Payment.Portal.Common/.
  
 # Install Gulp CLI globally and project dependencies
 WORKDIR "/src/EPR.Payment.Portal"
-RUN npm install -g gulp-cli --ignore-scripts && npm install --ignore-scripts
+RUN npm install -g gulp-cli && npm install --ignore-scripts
  
 # Run Gulp build task
 RUN gulp build-frontend

--- a/src/EPR.Payment.Portal/Dockerfile
+++ b/src/EPR.Payment.Portal/Dockerfile
@@ -32,7 +32,7 @@ COPY EPR.Payment.Portal.Common/. ./EPR.Payment.Portal.Common/.
  
 # Install Gulp CLI globally and project dependencies
 WORKDIR "/src/EPR.Payment.Portal"
-RUN npm install -g gulp-cli && npm install
+RUN npm install -g gulp-cli --ignore-scripts && npm install --ignore-scripts
  
 # Run Gulp build task
 RUN gulp build-frontend

--- a/src/EPR.Payment.Portal/Dockerfile
+++ b/src/EPR.Payment.Portal/Dockerfile
@@ -27,8 +27,8 @@ COPY ["EPR.Payment.Portal/EPR.Payment.Portal.csproj", "EPR.Payment.Portal/"]
 COPY ["EPR.Payment.Portal.Common/EPR.Payment.Portal.Common.csproj", "EPR.Payment.Portal.Common/"]
 RUN dotnet restore "EPR.Payment.Portal/EPR.Payment.Portal.csproj"
  
-COPY --chown=dotnet:dotnet EPR.Payment.Portal/. ./EPR.Payment.Portal/.
-COPY --chown=dotnet:dotnet EPR.Payment.Portal.Common/. ./EPR.Payment.Portal.Common/.
+COPY EPR.Payment.Portal/. ./EPR.Payment.Portal/.
+COPY EPR.Payment.Portal.Common/. ./EPR.Payment.Portal.Common/.
  
 # Install Gulp CLI globally and project dependencies
 WORKDIR "/src/EPR.Payment.Portal"

--- a/src/EPR.Payment.Portal/Dockerfile
+++ b/src/EPR.Payment.Portal/Dockerfile
@@ -32,7 +32,7 @@ COPY EPR.Payment.Portal.Common/. ./EPR.Payment.Portal.Common/.
  
 # Install Gulp CLI globally and project dependencies
 WORKDIR "/src/EPR.Payment.Portal"
-RUN npm install -g gulp-cli && npm install --ignore-scripts
+RUN npm install --ignore-scripts -g gulp-cli && npm install --ignore-scripts
  
 # Run Gulp build task
 RUN gulp build-frontend


### PR DESCRIPTION
The underlisted was done in order to fix some of the security and maintainability issues that was raised by Sonarqube:

1. Removed --chown=dotnet:dotnet from the dockerfile
2. Moved the CancellationToken to the last parameter in the test constructors
3. Passed a timeout to the Regex operation
4. Removed the TODO flag because SonarQube flagged it
5. Replaced the throw new ArgumentNullException with ArgumentNullException.ThrowIfNull
6. Replaced the string.EndsWith(string) with string.EndsWith(char) as the argument is a string with a single char