### PR TITLE
feature/bugs/478432-Payment-success-screen-content-layout

### DIFF
--- a/src/EPR.Payment.Portal/Views/GovPaySuccess/Index.cshtml
+++ b/src/EPR.Payment.Portal/Views/GovPaySuccess/Index.cshtml
@@ -11,12 +11,14 @@
 
 <main class="govuk-main-wrapper govuk-!-padding-top-8" id="main-content">
     <div class="govuk-grid-row">
-        <div class="govuk-panel govuk-panel--confirmation">
-            <h1 class="govuk-panel__title">
-                @Localizer["payment_successful"]
-            </h1>
-            <div class="govuk-panel__body">
-                @Localizer[@Model.completePaymentViewModel.Description == PaymentDescription.RegistrationFee ? "registration_fee_paid" : "packaging_fee_paid"]
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <div class="govuk-panel govuk-panel--confirmation">
+                <h1 class="govuk-panel__title">
+                    @Localizer["payment_successful"]
+                </h1>
+                <div class="govuk-panel__body">
+                    @Localizer[@Model.completePaymentViewModel.Description == PaymentDescription.RegistrationFee ? "registration_fee_paid" : "packaging_fee_paid"]
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
478432 Payment Success Screen content layout is not matching with Prototype